### PR TITLE
Feat: 파일 업로드 및 관리 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.30</version> <!-- 최신 버전 확인 후 업데이트 -->
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -127,6 +128,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/pplip/domain/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/pplip/domain/auth/filter/CustomLoginFilter.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/com/pplip/domain/auth/utils/SecurityUtils.java
+++ b/src/main/java/com/pplip/domain/auth/utils/SecurityUtils.java
@@ -1,0 +1,23 @@
+package com.pplip.domain.auth.utils;
+
+import com.pplip.domain.auth.persistence.entity.Account;
+import com.pplip.domain.user.persistence.dao.UserDao;
+import com.pplip.domain.user.persistence.entity.User;
+import com.pplip.global.api.code.ErrorCode;
+import com.pplip.global.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityUtils {
+
+	private final UserDao userDao;
+
+	public User getLoginUser(UserDetails principal) {
+		Long userId = ((Account) principal).getUserId();
+		return userDao.findById(userId).orElseThrow(() -> new BusinessLogicException(ErrorCode.USER_NOT_FOUND_ERROR, "인증되지 않은 사용자입니다."));
+	}
+
+}

--- a/src/main/java/com/pplip/domain/board/notice/persistence/entity/NoticeComment.java
+++ b/src/main/java/com/pplip/domain/board/notice/persistence/entity/NoticeComment.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 public class NoticeComment {
     private Long id;
-    private Long NoticeboardId;
+    private Long noticeBoardId;
     private Long authorId;
 
     private String content;

--- a/src/main/java/com/pplip/domain/file/api/controller/FileController.java
+++ b/src/main/java/com/pplip/domain/file/api/controller/FileController.java
@@ -2,13 +2,18 @@ package com.pplip.domain.file.api.controller;
 
 import com.pplip.domain.file.api.response.FileResponse;
 import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.usecase.FileService;
 import com.pplip.global.api.code.SuccessCode;
 import com.pplip.global.api.response.CommonResponse;
 import com.pplip.global.docs.FileDocsController;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 /**
  * 파일 관련 API 요청을 처리하는 컨트롤러
@@ -17,34 +22,51 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/file")
 @RequiredArgsConstructor
 public class FileController implements FileDocsController {
+	private final FileService fileService;
 
-    /**
-     * 이미지 파일을 업로드합니다.
-     *
-     * @param multipartFile 업로드할 이미지 파일
-     * @param imageType 이미지 유형 (e.g., PROFILE, BOARD)
-     * @return 업로드된 파일 정보와 함께 성공 응답을 반환
-     */
-    @PostMapping(path = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Override
-    public CommonResponse<FileResponse> upload(
-            @RequestPart
-            MultipartFile multipartFile,
-            @RequestParam
-            ImageType imageType) {
-        return CommonResponse.success(SuccessCode.CREATED, null);
-    }
+	/**
+	 * 이미지 파일을 업로드합니다.
+	 *
+	 * @param multipartFile 업로드할 이미지 파일
+	 * @param imageType     이미지 유형 (e.g., PROFILE, BOARD)
+	 * @return 업로드된 파일 정보와 함께 성공 응답을 반환
+	 */
+	@PostMapping(path = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Override
+	public CommonResponse<FileResponse> upload(
+			@RequestPart("file")
+			MultipartFile multipartFile,
+			@RequestParam
+			ImageType imageType,
+			@AuthenticationPrincipal
+			UserDetails userDetails
+	) {
+		return CommonResponse.success(SuccessCode.CREATED, fileService.saveFile(multipartFile, imageType, userDetails));
+	}
+
+	@PostMapping(path = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public CommonResponse<List<FileResponse>> uploads(
+			@RequestPart("files")
+			List<MultipartFile> files,
+			@RequestParam
+			ImageType imageType,
+			@AuthenticationPrincipal
+			UserDetails userDetails) {
+        return CommonResponse.success(SuccessCode.CREATED, fileService.saveFiles(files, imageType, userDetails));
+	}
 
 
-    /**
-     * 이미지 파일을 삭제합니다.
-     *
-     * @param id 삭제할 이미지 id
-     * @return 삭제된 파일 정보와 함께 성공 응답을 반환
-     */
-    @DeleteMapping("/images/{id}")
-    @Override
-    public CommonResponse<FileResponse> deleteFile(@PathVariable Long id){
-        return CommonResponse.success(SuccessCode.REMOVED, null);
-    }
+	/**
+	 * 이미지 파일을 삭제합니다.
+	 *
+	 * @param id 삭제할 이미지 id
+	 * @return 삭제된 파일 정보와 함께 성공 응답을 반환
+	 */
+	@DeleteMapping("/images/{id}")
+	@Override
+	public CommonResponse<FileResponse> deleteFile(@PathVariable Long id,
+	                                               @AuthenticationPrincipal UserDetails principal,
+	                                               @RequestParam ImageType imageType) {
+		return CommonResponse.success(SuccessCode.REMOVED, fileService.remove(id, imageType, principal));
+	}
 }

--- a/src/main/java/com/pplip/domain/file/api/response/FileResponse.java
+++ b/src/main/java/com/pplip/domain/file/api/response/FileResponse.java
@@ -1,5 +1,6 @@
 package com.pplip.domain.file.api.response;
 
+import com.pplip.domain.file.persistence.entity.ImageType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,4 +16,5 @@ public class FileResponse {
     private String contentType;
     private Long size;
     private String path;
+    private ImageType imageType;
 }

--- a/src/main/java/com/pplip/domain/file/persistence/dao/BatchSupportFilePropertyDao.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/BatchSupportFilePropertyDao.java
@@ -1,0 +1,37 @@
+package com.pplip.domain.file.persistence.dao;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+
+import java.util.List;
+
+
+/**
+ * {@link FilePropertyDao}를 확장하여 배치 처리를 지원하는 인터페이스
+ * @param <T> 파일 속성 타입
+ */
+public interface BatchSupportFilePropertyDao<T extends FileProperty> extends FilePropertyDao<T>  {
+	/**
+	 * 여러 이미지의 참조 ID를 일괄적으로 업데이트합니다.
+	 *
+	 * @param imageIds 업데이트할 이미지 ID 목록
+	 * @param refId 참조 ID
+	 * @return 업데이트된 행의 수
+	 */
+	int bulkUpdate(List<Long> imageIds, Long refId);
+
+	/**
+	 * 여러 파일 속성을 한 번에 저장합니다.
+	 *
+	 * @param list 저장할 파일 속성 목록
+	 * @return 삽입된 행의 수
+	 */
+	int insertAll(List<T> list);
+
+	/**
+	 * 지정된 ID 목록으로 모든 파일 속성을 찾습니다.
+	 *
+	 * @param fileIds 찾을 파일 속성의 ID 목록
+	 * @return 파일 속성 목록
+	 */
+	List<T> findAllByIds(List<Long> fileIds);
+}

--- a/src/main/java/com/pplip/domain/file/persistence/dao/FilePropertyDao.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/FilePropertyDao.java
@@ -1,0 +1,46 @@
+package com.pplip.domain.file.persistence.dao;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 파일 속성 데이터 액세스 작업을 위한 계약을 정의하는 인터페이스
+ * @param <T> 파일 속성 타입
+ */
+public interface FilePropertyDao <T extends FileProperty>{
+	/**
+	 * 파일 속성을 저장합니다.
+	 *
+	 * @param property 저장할 파일 속성
+	 * @return 삽입된 행의 수
+	 */
+	int insert(T property);
+
+	/**
+	 * 지정된 ID의 파일 속성을 삭제합니다.
+	 *
+	 * @param id 삭제할 파일 속성의 ID
+	 * @return 삭제된 행의 수
+	 */
+	int delete(Long id);
+
+	/**
+	 * 지정된 ID의 파일 속성을 찾습니다.
+	 *
+	 * @param id 찾을 파일 속성의 ID
+	 * @return 파일 속성(옵셔널)
+	 */
+	Optional<T> findById(Long id);
+
+	/**
+	 * 지정된 이미지 유형을 지원하는지 확인합니다.
+	 *
+	 * @param imageType 확인할 이미지 유형
+	 * @return 지원하면 true, 그렇지 않으면 false
+	 */
+	boolean supports(ImageType imageType);
+}

--- a/src/main/java/com/pplip/domain/file/persistence/dao/FreeBoardImagePropertyDao.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/FreeBoardImagePropertyDao.java
@@ -1,15 +1,50 @@
 package com.pplip.domain.file.persistence.dao;
 
+import com.pplip.domain.file.persistence.dao.mapper.FreeBoardImagePropertyMapper;
 import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
-import org.apache.ibatis.annotations.Mapper;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
-@Mapper
-public interface FreeBoardImagePropertyDao {
-    int insert(FreeBoardImageProperty property);
+@Repository
+@RequiredArgsConstructor
+public class FreeBoardImagePropertyDao implements BatchSupportFilePropertyDao<FreeBoardImageProperty>{
+	private final FreeBoardImagePropertyMapper mapper;
+	@Override
+	public int insert(FreeBoardImageProperty property) {
+		return mapper.insert(property);
+	}
 
-    int delete(Long id);
+	@Override
+	public int delete(Long id) {
+		return mapper.delete(id);
+	}
 
-    int bulkUpdateBoardId(List<Long> imageIds, Long boardId);
+	@Override
+	public Optional<FreeBoardImageProperty> findById(Long id) {
+		return mapper.findById(id);
+	}
+
+	@Override
+	public int bulkUpdate(List<Long> imageIds, Long refId) {
+		return mapper.bulkUpdateBoardId(imageIds, refId);
+	}
+
+	@Override
+	public int insertAll(List<FreeBoardImageProperty> list) {
+		return mapper.insertAll(list);
+	}
+
+	@Override
+	public List<FreeBoardImageProperty> findAllByIds(List<Long> fileIds) {
+		return mapper.findAllByIds(fileIds);
+	}
+
+	@Override
+	public boolean supports(ImageType imageType) {
+		return ImageType.FREE_BOARD.equals(imageType);
+	}
 }

--- a/src/main/java/com/pplip/domain/file/persistence/dao/NoticeBoardImagePropertyDao.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/NoticeBoardImagePropertyDao.java
@@ -1,15 +1,51 @@
 package com.pplip.domain.file.persistence.dao;
 
-import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
-import org.apache.ibatis.annotations.Mapper;
+import com.pplip.domain.file.persistence.dao.mapper.NoticeBoardImagePropertyMapper;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.NoticeBoardImageProperty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
-@Mapper
-public interface NoticeBoardImagePropertyDao {
-    int insert(FreeBoardImageProperty property);
+@Repository
+@RequiredArgsConstructor
+public class NoticeBoardImagePropertyDao implements BatchSupportFilePropertyDao<NoticeBoardImageProperty>{
+	private final NoticeBoardImagePropertyMapper mapper;
+	@Override
+	public int insert(NoticeBoardImageProperty property) {
+		return mapper.insert(property);
+	}
 
-    int delete(Long id);
+	@Override
+	public int delete(Long id) {
+		return mapper.delete(id);
+	}
 
-    int bulkUpdateBoardId(List<Long> imageIds, Long boardId);
+	@Override
+	public Optional<NoticeBoardImageProperty> findById(Long id) {
+		return mapper.findById(id);
+	}
+
+
+	@Override
+	public int bulkUpdate(List<Long> imageIds, Long refId) {
+		return mapper.bulkUpdateBoardId(imageIds, refId);
+	}
+
+	@Override
+	public int insertAll(List<NoticeBoardImageProperty> list) {
+		return mapper.insertAll(list);
+	}
+
+	@Override
+	public List<NoticeBoardImageProperty> findAllByIds(List<Long> fileIds) {
+		return mapper.findAllByIds(fileIds);
+	}
+
+	@Override
+	public boolean supports(ImageType imageType) {
+		return ImageType.NOTICE.equals(imageType);
+	}
 }

--- a/src/main/java/com/pplip/domain/file/persistence/dao/ProfileImagePropertyDao.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/ProfileImagePropertyDao.java
@@ -1,11 +1,36 @@
 package com.pplip.domain.file.persistence.dao;
 
+import com.pplip.domain.file.persistence.dao.mapper.ProfileImagePropertyMapper;
+import com.pplip.domain.file.persistence.entity.ImageType;
 import com.pplip.domain.file.persistence.entity.ProfileImageProperty;
-import org.apache.ibatis.annotations.Mapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
-@Mapper
-public interface ProfileImagePropertyDao {
-    int insert(ProfileImageProperty property);
+import java.util.Optional;
 
-    int delete(Long id);
+
+@RequiredArgsConstructor
+@Repository
+public class ProfileImagePropertyDao implements FilePropertyDao<ProfileImageProperty> {
+	private final ProfileImagePropertyMapper profileImagePropertyMapper;
+	@Override
+	public int insert(ProfileImageProperty property) {
+		return profileImagePropertyMapper.insert(property);
+	}
+
+	@Override
+	public int delete(Long id) {
+		return profileImagePropertyMapper.delete(id);
+	}
+
+	@Override
+	public Optional<ProfileImageProperty> findById(Long id) {
+		return profileImagePropertyMapper.findById(id);
+	}
+
+
+	@Override
+	public boolean supports(ImageType imageType) {
+		return ImageType.PROFILE.equals(imageType);
+	}
 }

--- a/src/main/java/com/pplip/domain/file/persistence/dao/ReviewImagePropertyDao.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/ReviewImagePropertyDao.java
@@ -1,15 +1,52 @@
 package com.pplip.domain.file.persistence.dao;
 
+import com.pplip.domain.file.persistence.dao.mapper.ReviewImagePropertyMapper;
+import com.pplip.domain.file.persistence.entity.ImageType;
 import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
-import org.apache.ibatis.annotations.Mapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
-@Mapper
-public interface ReviewImagePropertyDao {
-    int insert(ReviewImageProperty property);
+@Repository
+@RequiredArgsConstructor
+public class ReviewImagePropertyDao implements BatchSupportFilePropertyDao<ReviewImageProperty> {
 
-    int delete(Long id);
+	private final ReviewImagePropertyMapper mapper;
 
-    int bulkUpdateReviewId(List<Long> imageIds, Long reviewId);
+	@Override
+	public int bulkUpdate(List<Long> imageIds, Long refId) {
+		return mapper.bulkUpdateReviewId(imageIds, refId);
+	}
+
+	@Override
+	public int insertAll(List<ReviewImageProperty> list) {
+		return mapper.insertAll(list);
+	}
+
+	@Override
+	public List<ReviewImageProperty> findAllByIds(List<Long> fileIds) {
+		return mapper.findAllByIds(fileIds);
+	}
+
+	@Override
+	public int insert(ReviewImageProperty property) {
+		return mapper.insert(property);
+	}
+
+	@Override
+	public int delete(Long id) {
+		return mapper.delete(id);
+	}
+
+	@Override
+	public Optional<ReviewImageProperty> findById(Long id) {
+		return mapper.findById(id);
+	}
+
+	@Override
+	public boolean supports(ImageType imageType) {
+		return ImageType.REVIEW.equals(imageType);
+	}
 }

--- a/src/main/java/com/pplip/domain/file/persistence/dao/mapper/FreeBoardImagePropertyMapper.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/mapper/FreeBoardImagePropertyMapper.java
@@ -1,0 +1,63 @@
+package com.pplip.domain.file.persistence.dao.mapper;
+
+import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 자유 게시판 이미지 속성 관련 데이터베이스 작업을 위한 매퍼 인터페이스
+ */
+@Mapper
+public interface FreeBoardImagePropertyMapper{
+    /**
+     * 새로운 자유 게시판 이미지 속성을 삽입합니다.
+     *
+     * @param property 삽입할 이미지 속성 객체
+     * @return 삽입된 행의 수
+     */
+    int insert(FreeBoardImageProperty property);
+
+    /**
+     * 지정된 ID를 가진 자유 게시판 이미지 속성을 삭제합니다.
+     *
+     * @param id 삭제할 이미지 속성의 ID
+     * @return 삭제된 행의 수
+     */
+    int delete(Long id);
+
+    /**
+     * 지정된 ID를 가진 자유 게시판 이미지 속성을 찾습니다.
+     *
+     * @param id 찾을 이미지 속성의 ID
+     * @return 이미지 속성(존재하는 경우 Optional로 감싸짐)
+     */
+    Optional<FreeBoardImageProperty> findById(Long id);
+
+    /**
+     * 자유 게시판 이미지 속성 목록을 일괄 삽입합니다.
+     *
+     * @param list 삽입할 이미지 속성 객체 리스트
+     * @return 삽입된 행의 수
+     */
+    int insertAll(List<FreeBoardImageProperty> list);
+
+    /**
+     * 여러 자유 게시판 이미지의 게시판 ID를 일괄 업데이트합니다.
+     *
+     * @param imageIds 업데이트할 이미지 ID 목록
+     * @param boardId 설정할 게시판 ID
+     * @return 업데이트된 행의 수
+     */
+    int bulkUpdateBoardId(List<Long> imageIds, Long boardId);
+
+    /**
+     * 지정된 ID 목록으로 모든 자유 게시판 이미지 속성을 찾습니다.
+     *
+     * @param fileIds 찾을 파일 속성의 ID 목록
+     * @return 자유 게시판 이미지 속성 목록
+     */
+    List<FreeBoardImageProperty> findAllByIds(List<Long> fileIds);
+}

--- a/src/main/java/com/pplip/domain/file/persistence/dao/mapper/NoticeBoardImagePropertyMapper.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/mapper/NoticeBoardImagePropertyMapper.java
@@ -1,0 +1,64 @@
+package com.pplip.domain.file.persistence.dao.mapper;
+
+import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.NoticeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 공지사항 이미지 속성 관련 데이터베이스 작업을 위한 매퍼 인터페이스
+ */
+@Mapper
+public interface NoticeBoardImagePropertyMapper{
+    /**
+     * 새로운 공지사항 이미지 속성을 삽입합니다.
+     *
+     * @param property 삽입할 이미지 속성 객체
+     * @return 삽입된 행의 수
+     */
+    int insert(NoticeBoardImageProperty property);
+
+    /**
+     * 지정된 ID를 가진 공지사항 이미지 속성을 삭제합니다.
+     *
+     * @param id 삭제할 이미지 속성의 ID
+     * @return 삭제된 행의 수
+     */
+    int delete(Long id);
+
+    /**
+     * 공지사항 이미지 속성 목록을 일괄 삽입합니다.
+     *
+     * @param list 삽입할 이미지 속성 객체 리스트
+     * @return 삽입된 행의 수
+     */
+    int insertAll(List<NoticeBoardImageProperty> list);
+
+    /**
+     * 지정된 ID를 가진 공지사항 이미지 속성을 찾습니다.
+     *
+     * @param id 찾을 이미지 속성의 ID
+     * @return 이미지 속성(존재하는 경우 Optional로 감싸짐)
+     */
+    Optional<NoticeBoardImageProperty> findById(Long id);
+
+    /**
+     * 여러 공지사항 이미지의 게시판 ID를 일괄 업데이트합니다.
+     *
+     * @param imageIds 업데이트할 이미지 ID 목록
+     * @param boardId 설정할 게시판 ID
+     * @return 업데이트된 행의 수
+     */
+    int bulkUpdateBoardId(List<Long> imageIds, Long boardId);
+
+    /**
+     * 지정된 ID 목록으로 모든 공지사항 이미지 속성을 찾습니다.
+     *
+     * @param fileIds 찾을 이미지 속성의 ID 목록
+     * @return 공지사항 이미지 속성 목록
+     */
+    List<NoticeBoardImageProperty> findAllByIds(List<Long> fileIds);
+}

--- a/src/main/java/com/pplip/domain/file/persistence/dao/mapper/ProfileImagePropertyMapper.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/mapper/ProfileImagePropertyMapper.java
@@ -1,0 +1,37 @@
+package com.pplip.domain.file.persistence.dao.mapper;
+
+import com.pplip.domain.file.persistence.entity.ProfileImageProperty;
+import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+/**
+ * 프로필 이미지 속성 관련 데이터베이스 작업을 위한 매퍼 인터페이스
+ */
+@Mapper
+public interface ProfileImagePropertyMapper{
+    /**
+     * 새로운 프로필 이미지 속성을 삽입합니다.
+     *
+     * @param property 삽입할 이미지 속성 객체
+     * @return 삽입된 행의 수
+     */
+    int insert(ProfileImageProperty property);
+
+    /**
+     * 지정된 ID를 가진 프로필 이미지 속성을 찾습니다.
+     *
+     * @param id 찾을 이미지 속성의 ID
+     * @return 이미지 속성(존재하는 경우 Optional로 감싸짐)
+     */
+    Optional<ProfileImageProperty> findById(Long id);
+
+    /**
+     * 지정된 ID를 가진 프로필 이미지 속성을 삭제합니다.
+     *
+     * @param id 삭제할 이미지 속성의 ID
+     * @return 삭제된 행의 수
+     */
+    int delete(Long id);
+}

--- a/src/main/java/com/pplip/domain/file/persistence/dao/mapper/ReviewImagePropertyMapper.java
+++ b/src/main/java/com/pplip/domain/file/persistence/dao/mapper/ReviewImagePropertyMapper.java
@@ -1,0 +1,63 @@
+package com.pplip.domain.file.persistence.dao.mapper;
+
+import com.pplip.domain.file.persistence.entity.NoticeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 리뷰 이미지 속성 관련 데이터베이스 작업을 위한 매퍼 인터페이스
+ */
+@Mapper
+public interface ReviewImagePropertyMapper{
+    /**
+     * 새로운 리뷰 이미지 속성을 삽입합니다.
+     *
+     * @param property 삽입할 이미지 속성 객체
+     * @return 삽입된 행의 수
+     */
+    int insert(ReviewImageProperty property);
+
+    /**
+     * 지정된 ID를 가진 리뷰 이미지 속성을 삭제합니다.
+     *
+     * @param id 삭제할 이미지 속성의 ID
+     * @return 삭제된 행의 수
+     */
+    int delete(Long id);
+
+    /**
+     * 리뷰 이미지 속성 목록을 일괄 삽입합니다.
+     *
+     * @param list 삽입할 이미지 속성 객체 리스트
+     * @return 삽입된 행의 수
+     */
+    int insertAll(List<ReviewImageProperty> list);
+
+    /**
+     * 지정된 ID를 가진 리뷰 이미지 속성을 찾습니다.
+     *
+     * @param id 찾을 이미지 속성의 ID
+     * @return 이미지 속성(존재하는 경우 Optional로 감싸짐)
+     */
+    Optional<ReviewImageProperty> findById(Long id);
+
+    /**
+     * 여러 리뷰 이미지의 리뷰 ID를 일괄 업데이트합니다.
+     *
+     * @param imageIds 업데이트할 이미지 ID 목록
+     * @param reviewId 설정할 리뷰 ID
+     * @return 업데이트된 행의 수
+     */
+    int bulkUpdateReviewId(List<Long> imageIds, Long reviewId);
+
+    /**
+     * 지정된 ID 목록으로 모든 리뷰 이미지 속성을 찾습니다.
+     *
+     * @param fileIds 찾을 파일 속성의 ID 목록
+     * @return 리뷰 이미지 속성 목록
+     */
+    List<ReviewImageProperty> findAllByIds(List<Long> fileIds);
+}

--- a/src/main/java/com/pplip/domain/file/persistence/entity/FileProperty.java
+++ b/src/main/java/com/pplip/domain/file/persistence/entity/FileProperty.java
@@ -1,21 +1,25 @@
 package com.pplip.domain.file.persistence.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 public abstract class FileProperty {
     private Long id;
     private String originFileName;
     private String path;
+    private String contentType;
     private String savedFileName;
+    private Long uploaderId;
     private long size;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
 }

--- a/src/main/java/com/pplip/domain/file/persistence/entity/FreeBoardImageProperty.java
+++ b/src/main/java/com/pplip/domain/file/persistence/entity/FreeBoardImageProperty.java
@@ -1,14 +1,19 @@
 package com.pplip.domain.file.persistence.entity;
 
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class FreeBoardImageProperty extends FileProperty {
 
-    private Long boardId;
+	private Long boardId;
+
 }

--- a/src/main/java/com/pplip/domain/file/persistence/entity/NoticeBoardImageProperty.java
+++ b/src/main/java/com/pplip/domain/file/persistence/entity/NoticeBoardImageProperty.java
@@ -1,12 +1,15 @@
 package com.pplip.domain.file.persistence.entity;
 
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 public class NoticeBoardImageProperty extends FileProperty {
     private Long boardId;
+
+
 }

--- a/src/main/java/com/pplip/domain/file/persistence/entity/ProfileImageProperty.java
+++ b/src/main/java/com/pplip/domain/file/persistence/entity/ProfileImageProperty.java
@@ -1,13 +1,14 @@
 package com.pplip.domain.file.persistence.entity;
 
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class ProfileImageProperty extends FileProperty {
 
     private Long profileId;

--- a/src/main/java/com/pplip/domain/file/persistence/entity/ReviewImageProperty.java
+++ b/src/main/java/com/pplip/domain/file/persistence/entity/ReviewImageProperty.java
@@ -1,12 +1,15 @@
 package com.pplip.domain.file.persistence.entity;
 
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 public class ReviewImageProperty extends FileProperty {
     private Long reviewId;
+
+
 }

--- a/src/main/java/com/pplip/domain/file/persistence/entity/StoryBookImageProperty.java
+++ b/src/main/java/com/pplip/domain/file/persistence/entity/StoryBookImageProperty.java
@@ -4,5 +4,6 @@ package com.pplip.domain.file.persistence.entity;
 //TODO: 나중에 시간 남으면 스토리북 기능에 사용
 public class StoryBookImageProperty extends FileProperty {
 
+
 }
 

--- a/src/main/java/com/pplip/domain/file/usecase/AwsS3FileStorage.java
+++ b/src/main/java/com/pplip/domain/file/usecase/AwsS3FileStorage.java
@@ -1,0 +1,39 @@
+package com.pplip.domain.file.usecase;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.pplip.domain.file.utils.FileStorage;
+import com.pplip.global.api.code.ErrorCode;
+import com.pplip.global.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class AwsS3FileStorage implements FileStorage {
+
+	private final AmazonS3 s3;
+	@Value("${aws.s3.bucket}")
+	private String bucketName;
+
+	@Override
+	public void store(MultipartFile file, String path) {
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(file.getSize());
+		objectMetadata.setContentType(file.getContentType());
+		try {
+			s3.putObject(bucketName, path, file.getInputStream(), objectMetadata);
+		} catch (IOException e) {
+			throw new BusinessLogicException(ErrorCode.FILE_PROCESS_FAILURE, "파일 저장에 실패했습니다.");
+		}
+	}
+
+	@Override
+	public void delete(String path) {
+		s3.deleteObject(bucketName, path);
+	}
+}

--- a/src/main/java/com/pplip/domain/file/usecase/FileService.java
+++ b/src/main/java/com/pplip/domain/file/usecase/FileService.java
@@ -1,0 +1,43 @@
+package com.pplip.domain.file.usecase;
+
+import com.pplip.domain.file.api.response.FileResponse;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 파일 관련 비즈니스 로직을 정의하는 인터페이스
+ */
+public interface FileService {
+	/**
+	 * 단일 파일을 저장합니다.
+	 *
+	 * @param file 저장할 파일
+	 * @param imageType 이미지 유형
+	 * @param userDetails 사용자 정보
+	 * @return 저장된 파일 정보
+	 */
+	FileResponse saveFile(MultipartFile file, ImageType imageType, UserDetails userDetails);
+
+	/**
+	 * 파일을 삭제합니다.
+	 *
+	 * @param id 파일 ID
+	 * @param imageType 이미지 유형
+	 * @param principal 사용자 정보
+	 * @return 삭제된 파일 정보
+	 */
+	FileResponse remove(Long id, ImageType imageType, UserDetails principal);
+
+	/**
+	 * 여러 파일을 저장합니다.
+	 *
+	 * @param files 저장할 파일 목록
+	 * @param imageType 이미지 유형
+	 * @param userDetails 사용자 정보
+	 * @return 저장된 파일 정보 목록
+	 */
+	List<FileResponse> saveFiles(List<? extends MultipartFile> files, ImageType imageType, UserDetails userDetails);
+}

--- a/src/main/java/com/pplip/domain/file/usecase/FileServiceImpl.java
+++ b/src/main/java/com/pplip/domain/file/usecase/FileServiceImpl.java
@@ -1,0 +1,104 @@
+package com.pplip.domain.file.usecase;
+
+import com.pplip.domain.auth.utils.SecurityUtils;
+import com.pplip.domain.file.api.response.FileResponse;
+import com.pplip.domain.file.persistence.dao.BatchSupportFilePropertyDao;
+import com.pplip.domain.file.persistence.dao.FilePropertyDao;
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.utils.FilePropertyProvider;
+import com.pplip.domain.file.utils.FileStorage;
+import com.pplip.domain.user.persistence.entity.User;
+import com.pplip.global.api.code.ErrorCode;
+import com.pplip.global.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FileServiceImpl implements FileService {
+	private final FilePropertyProvider provider;
+	private final FileStorage fileStorage;
+	private final SecurityUtils securityUtils;
+	private final List<FilePropertyDao<FileProperty>> filePropertyDaos;
+	private final List<BatchSupportFilePropertyDao<FileProperty>> batchSupportFilePropertyDaos;
+
+	@Override
+	public FileResponse saveFile(MultipartFile file, ImageType imageType, UserDetails userDetails) {
+		User user = securityUtils.getLoginUser(userDetails);
+		FileProperty fileProperty = provider.create(file.getOriginalFilename(), file.getContentType(), file.getSize(), user, imageType);
+		fileStorage.store(file, fileProperty.getPath());
+
+		return filePropertyDaos.stream().filter(fdao -> fdao.supports(imageType)).map(fdao -> {
+			fdao.insert(fileProperty);
+			return FileResponse.builder()
+					.id(fileProperty.getId())
+					.path(fileProperty.getPath())
+					.contentType(fileProperty.getContentType())
+					.name(fileProperty.getOriginFileName())
+					.imageType(imageType)
+					.size(fileProperty.getSize())
+					.build();
+		}).findFirst().orElseThrow(() -> new BusinessLogicException(ErrorCode.FILE_PROCESS_FAILURE, "파일 저장에 실패하였습니다."));
+	}
+
+
+	@Override
+	public FileResponse remove(Long id, ImageType imageType, UserDetails userDetails) {
+		User loginUser = securityUtils.getLoginUser(userDetails);
+		return filePropertyDaos.stream().filter(fdao -> fdao.supports(imageType)).map(fdao -> {
+			FileProperty fileProperty = fdao.findById(id).orElseThrow(() -> new BusinessLogicException(ErrorCode.FILE_TYPE_NOT_SUPPORT, "파일을 찾을 수 없습니다."));
+			if (!fileProperty.getUploaderId().equals(loginUser.getId())) {
+				throw new BusinessLogicException(ErrorCode.INVALIDATED_USER_ERROR, "업로드한 사용자만 삭제할 수 있습니다.");
+			}
+			int delete = fdao.delete(fileProperty.getId());
+			if (delete == 0) {
+				throw new BusinessLogicException(ErrorCode.FILE_PROCESS_FAILURE, "삭제된 파일 프로퍼티가 존재하지 않습니다.");
+			}
+			fileStorage.delete(fileProperty.getPath());
+			return FileResponse.builder()
+					.id(fileProperty.getId())
+					.path(fileProperty.getPath())
+					.contentType(fileProperty.getContentType())
+					.name(fileProperty.getOriginFileName())
+					.size(fileProperty.getSize())
+					.imageType(imageType).build();
+		}).findFirst().orElseThrow(() -> new BusinessLogicException(ErrorCode.FILE_PROCESS_FAILURE, "파일 삭제에 실패했습니다."));
+	}
+
+	@Override
+	public List<FileResponse> saveFiles(List<? extends MultipartFile> files, ImageType imageType, UserDetails userDetails) {
+		User user = securityUtils.getLoginUser(userDetails);
+		List<FileProperty> fileProperties = new ArrayList<>();
+		for (MultipartFile file : files) {
+			FileProperty fileProperty = provider.create(file.getOriginalFilename(), file.getContentType(), file.getSize(), user, imageType);
+			fileStorage.store(file, fileProperty.getPath());
+			fileProperties.add(fileProperty);
+		}
+		batchSupportFilePropertyDaos.stream().filter(fdao -> fdao.supports(imageType)).forEach(fdao ->
+				fdao.insertAll(fileProperties)
+		);
+		return fileProperties.stream().map(fileProperty -> FileResponse.builder()
+				.id(fileProperty.getId())
+				.path(fileProperty.getPath())
+				.contentType(fileProperty.getContentType())
+				.name(fileProperty.getOriginFileName())
+				.imageType(imageType)
+				.size(fileProperty.getSize())
+				.build()).toList();
+	}
+
+	public int bulkUpdateFiles(List<Long> fileIds, ImageType imageType, Long refId) {
+		return batchSupportFilePropertyDaos.stream().filter(fdao -> fdao.supports(imageType))
+				.mapToInt(fdao ->
+						fdao.bulkUpdate(fileIds, refId)
+				).sum();
+	}
+}

--- a/src/main/java/com/pplip/domain/file/utils/FilePropertyProvider.java
+++ b/src/main/java/com/pplip/domain/file/utils/FilePropertyProvider.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class FileFactoryProvider {
+public class FilePropertyProvider {
     private final List<FilePropertyFactory> fileProperties;
     private final FilePathGenerator filePathGenerator;
 

--- a/src/main/java/com/pplip/domain/file/utils/FileStorage.java
+++ b/src/main/java/com/pplip/domain/file/utils/FileStorage.java
@@ -2,6 +2,8 @@ package com.pplip.domain.file.utils;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 /**
  * 파일 저장소 작업을 위한 계약을 정의하는 인터페이스
  */

--- a/src/main/java/com/pplip/domain/file/utils/factory/FreeBoardImagePropertyFactory.java
+++ b/src/main/java/com/pplip/domain/file/utils/factory/FreeBoardImagePropertyFactory.java
@@ -1,0 +1,30 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.user.persistence.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class FreeBoardImagePropertyFactory implements FilePropertyFactory {
+	@Override
+	public FileProperty create(String originFileName, String saveFileName, String path, String contentType, Long size, User uploader, ImageType imageType) {
+		return FreeBoardImageProperty
+				.builder()
+				.originFileName(originFileName)
+				.savedFileName(saveFileName)
+				.path(path)
+				.contentType(contentType)
+				.size(size)
+				.uploaderId(uploader.getId())
+				.createdAt(LocalDateTime.now()).build();
+	}
+
+	@Override
+	public boolean support(ImageType imageType) {
+		return ImageType.FREE_BOARD.equals(imageType);
+	}
+}

--- a/src/main/java/com/pplip/domain/file/utils/factory/NoticeBoardImagePropertyFactory.java
+++ b/src/main/java/com/pplip/domain/file/utils/factory/NoticeBoardImagePropertyFactory.java
@@ -1,0 +1,30 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.NoticeBoardImageProperty;
+import com.pplip.domain.user.persistence.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class NoticeBoardImagePropertyFactory implements FilePropertyFactory{
+	@Override
+	public FileProperty create(String originFileName, String saveFileName, String path, String contentType, Long size, User uploader, ImageType imageType) {
+		return NoticeBoardImageProperty.builder()
+				.originFileName(originFileName)
+				.size(size)
+				.path(path)
+				.savedFileName(saveFileName)
+				.contentType(contentType)
+				.uploaderId(uploader.getId())
+				.createdAt(LocalDateTime.now())
+				.build();
+	}
+
+	@Override
+	public boolean support(ImageType imageType) {
+		return ImageType.NOTICE.equals(imageType);
+	}
+}

--- a/src/main/java/com/pplip/domain/file/utils/factory/ProfileImagePropertyFactory.java
+++ b/src/main/java/com/pplip/domain/file/utils/factory/ProfileImagePropertyFactory.java
@@ -1,0 +1,30 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.ProfileImageProperty;
+import com.pplip.domain.user.persistence.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ProfileImagePropertyFactory implements FilePropertyFactory{
+	@Override
+	public FileProperty create(String originFileName, String saveFileName, String path, String contentType, Long size, User uploader, ImageType imageType) {
+		return ProfileImageProperty.builder()
+				.originFileName(originFileName)
+				.savedFileName(saveFileName)
+				.path(path)
+				.contentType(contentType)
+				.size(size)
+				.uploaderId(uploader.getId())
+				.createdAt(LocalDateTime.now())
+				.build();
+	}
+
+	@Override
+	public boolean support(ImageType imageType) {
+		return ImageType.PROFILE.equals(imageType);
+	}
+}

--- a/src/main/java/com/pplip/domain/file/utils/factory/ReviewImagePropertyFactory.java
+++ b/src/main/java/com/pplip/domain/file/utils/factory/ReviewImagePropertyFactory.java
@@ -1,0 +1,30 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
+import com.pplip.domain.user.persistence.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ReviewImagePropertyFactory implements FilePropertyFactory {
+	@Override
+	public FileProperty create(String originFileName, String saveFileName, String path, String contentType, Long size, User uploader, ImageType imageType) {
+		return ReviewImageProperty.builder()
+				.originFileName(originFileName)
+				.savedFileName(saveFileName)
+				.path(path)
+				.contentType(contentType)
+				.size(size)
+				.uploaderId(uploader.getId())
+				.createdAt(LocalDateTime.now())
+				.build();
+	}
+
+	@Override
+	public boolean support(ImageType imageType) {
+		return ImageType.REVIEW.equals(imageType);
+	}
+}

--- a/src/main/java/com/pplip/global/api/code/ErrorCode.java
+++ b/src/main/java/com/pplip/global/api/code/ErrorCode.java
@@ -7,7 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     USER_NOT_FOUND_ERROR(DomainCode.USER, ExceptionCode.NOT_FOUND, "USER_NOT_FOUND_ERROR"),
+    INVALIDATED_USER_ERROR(DomainCode.USER, ExceptionCode.INVALID, "USER_INVALIDATED"),
     FILE_TYPE_NOT_SUPPORT(DomainCode.FILE, ExceptionCode.NOT_SUPPORT, "FILE_TYPE_NOT_SUPPORT"),
+    FILE_PROCESS_FAILURE(DomainCode.FILE, ExceptionCode.FAILURE, "FILE_PROCESS_FAILURE"),
+    FILE_NOT_FOUND(DomainCode.FILE, ExceptionCode.NOT_FOUND,"FILE_NOT_FOUND"),
     UN_EXPECTED_TOKEN_VALIDATION(DomainCode.AUTH, ExceptionCode.UN_EXPECTED, "UN_EXPECTED_TOKEN_VALIDATION"),
     TOKEN_EXPIRED(DomainCode.AUTH, ExceptionCode.EXPIRED, "토큰이 만료되었습니다."),
     TOKEN_MALFORMED(DomainCode.AUTH, ExceptionCode.MALFORMED, "토큰이 위조되었습니다"),

--- a/src/main/java/com/pplip/global/api/code/ExceptionCode.java
+++ b/src/main/java/com/pplip/global/api/code/ExceptionCode.java
@@ -12,7 +12,7 @@ public enum ExceptionCode {
     UN_EXPECTED(5),
     EXPIRED(6),
     MALFORMED(7),
-    INVALID(8), ;
+    INVALID(8), FAILURE(4);
     private int value;
 
 }

--- a/src/main/java/com/pplip/global/config/AwsS3Config.java
+++ b/src/main/java/com/pplip/global/config/AwsS3Config.java
@@ -1,0 +1,31 @@
+package com.pplip.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+	@Value("${aws.s3.credentials.accessKey}")
+	private String accessKey;
+	@Value("${aws.s3.credentials.secretKey}")
+	private String secretKey;
+	@Value("${aws.s3.credentials.region}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3Client() {
+		BasicAWSCredentials credentails = new BasicAWSCredentials(accessKey, secretKey);
+
+		return AmazonS3ClientBuilder.standard()
+				.withCredentials(new AWSStaticCredentialsProvider(credentails))
+				.withRegion(region)
+				.build();
+	}
+
+
+}

--- a/src/main/java/com/pplip/global/config/SecurityConfig.java
+++ b/src/main/java/com/pplip/global/config/SecurityConfig.java
@@ -25,37 +25,42 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationProvider provider;
-    private final ObjectMapper om;
+	private final JwtAuthenticationProvider provider;
+	private final ObjectMapper om;
 
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtAuthenticationProvider provider) {
-        return new JwtAuthenticationFilter(provider);
-    }
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter(JwtAuthenticationProvider provider) {
+		return new JwtAuthenticationFilter(provider);
+	}
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.httpBasic(HttpBasicConfigurer::disable);
-        http.formLogin(FormLoginConfigurer::disable);
-        http.csrf(CsrfConfigurer::disable);
-        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        // api 설계 필요.
-        http.authorizeHttpRequests(req ->
-                req.anyRequest()
-                        .permitAll());
-        http.addFilterAt(customLoginFilter(), UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(
-                new JwtAuthenticationFilter(provider), UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(new JwtExceptionFilter(om), JwtAuthenticationFilter.class);
-        return http.build();
-    }
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.httpBasic(HttpBasicConfigurer::disable);
+		http.formLogin(FormLoginConfigurer::disable);
+		http.csrf(CsrfConfigurer::disable);
+		http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+		// api 설계 필요.
+		http.authorizeHttpRequests(req ->
+				req
+						.requestMatchers(
+								"/v3/api-docs/**",
+								"/swagger-ui/**",
+								"/swagger-ui.html"
+						).permitAll().anyRequest()
+						.permitAll());
+		http.addFilterAt(customLoginFilter(), UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(
+				new JwtAuthenticationFilter(provider), UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(new JwtExceptionFilter(om), JwtAuthenticationFilter.class);
+		return http.build();
+	}
 
-    public AbstractAuthenticationProcessingFilter customLoginFilter() {
-        CustomLoginFilter clf = new CustomLoginFilter(om);
-        clf.setAuthenticationSuccessHandler(new CustomLoginSuccessHandler());
-        clf.setAuthenticationFailureHandler(new CustomLoginFailureHandler(om));
-        return clf;
-    }
+	public AbstractAuthenticationProcessingFilter customLoginFilter() {
+		CustomLoginFilter clf = new CustomLoginFilter(om);
+		clf.setAuthenticationSuccessHandler(new CustomLoginSuccessHandler());
+		clf.setAuthenticationFailureHandler(new CustomLoginFailureHandler(om));
+		return clf;
+	}
 
 
 }

--- a/src/main/java/com/pplip/global/docs/FileDocsController.java
+++ b/src/main/java/com/pplip/global/docs/FileDocsController.java
@@ -6,6 +6,7 @@ import com.pplip.global.api.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -19,11 +20,12 @@ public interface FileDocsController {
      *
      * @param multipartFile 업로드할 이미지 파일
      * @param imageType     이미지 유형 (e.g., PROFILE, BOARD)
+     * @param userDetails 로그인 중인 사용자
      * @return 업로드된 파일 정보와 함께 성공 응답을 반환
      */
     @Operation(summary = "이미지 파일 업로드")
     @ApiResponse(responseCode = "201", description = "생성")
-    CommonResponse<FileResponse> upload(MultipartFile multipartFile, ImageType imageType);
+    CommonResponse<FileResponse> upload(MultipartFile multipartFile, ImageType imageType, UserDetails userDetails);
 
     /**
      * 이미지 파일을 삭제합니다.
@@ -33,5 +35,5 @@ public interface FileDocsController {
      */
     @Operation(summary = "이미지 파일 삭제")
     @ApiResponse(responseCode = "203", description = "성공")
-    CommonResponse<FileResponse> deleteFile(Long id);
+    CommonResponse<FileResponse> deleteFile(Long id, UserDetails principal, ImageType imageType);
 }

--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -31,4 +31,38 @@
 #    map-underscore-to-camel-case: #TRUE OR FALSE
 #
 #key_kakao_javascript: #Your_Key_Here
+#springdoc:
+#  swagger-ui:
+#    # 접속 경로 설정 (기본값: /swagger-ui/index.html)
+#    path: /swagger-ui.html
+#
+#    # API 그룹 표시 순서 (알파벳순 등)
+#    groups-order: DESC
+#
+#    # HTTP Method 순서 정렬 (GET, POST, PUT, DELETE 순 등)
+#    operations-sorter: method
+#
+#    # 태그(Controller) 정렬 순서 (alpha: 알파벳순)
+#    tags-sorter: alpha
+#
+#    # 'Try it out' 버튼 클릭 시 Request Duration(소요 시간) 표시
+#    display-request-duration: true
+#
+#    # 하단의 Schemas(DTO 모델) 섹션 기본적으로 펼쳐두기 (false면 접힘)
+#    default-models-expand-depth: 1
+#
+#  api-docs:
+#    # OpenAPI JSON 문서 경로
+#    path: /v3/api-docs
+#
+#  # 브라우저 탭에 표시될 문서 제목/버전 등 (선택 사항)
+#  # Java Config(@Configuration)에서 설정하는 것이 더 일반적이나 yml로도 일부 제어 가능
+#  show-actuator: true
 
+#aws:
+#  s3:
+#    credentials:
+#      accessKey: ${AWS_S3_ACCESS_KEY}
+#      secretKey: ${AWS_S3_SECRET_KEY}
+#      region: ${AWS_S3_REGION}
+#    bucket: ${AWS_S3_BUCKET}

--- a/src/main/resources/mapper/file/FreeBoardImagePropertyDaoMapper.xml
+++ b/src/main/resources/mapper/file/FreeBoardImagePropertyDaoMapper.xml
@@ -1,10 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.pplip.domain.file.persistence.dao.FreeBoardImagePropertyDao">
+<mapper namespace="com.pplip.domain.file.persistence.dao.mapper.FreeBoardImagePropertyMapper">
+
+    <resultMap id="freeBoardImagePropertyMap" type="com.pplip.domain.file.persistence.entity.FreeBoardImageProperty" autoMapping="true"/>
     <insert id="insert">
+        insert into free_board_image_property (board_id, origin_file_name, path, saved_file_name, size, created_at, content_type
+                                              ,updated_at, uploader_id)
+        values (#{boardId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{content_type}, #{updatedAt}, #{uploaderId});
+    </insert>
+
+
+    <insert id="insertAll">
         insert into free_board_image_property (board_id, origin_file_name, path, saved_file_name, size, created_at,
-                                              updated_at)
-        values (#{boardId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{updatedAt});
+        content_type
+        ,updated_at, uploader_id)
+        values
+        <foreach collection="list" index="index" item="image" separator=",">
+            (#{boardId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{content_type},
+            #{updatedAt}, #{uploaderId})
+        </foreach>
     </insert>
 
     <delete id="delete">
@@ -13,11 +27,29 @@
         where id = #{id};
     </delete>
 
+    <select id="findById" resultMap="freeBoardImagePropertyMap">
+        select *
+        from free_board_image_property
+        where id = #{id}
+    </select>
+
+    <select id="findAllByIds" resultMap="freeBoardImagePropertyMap">
+        select *
+        from free_board_image_property
+        where id in
+        <foreach collection="fileIds" item="id" open="(" close=")" separator=",">
+            #{id}
+        </foreach>
+    </select>
+
     <update id="bulkUpdateBoardId">
-        <foreach collection="imageIds" item="imageId" separator=";">
-            update free_board_image_property
-            set board_id = #{boardId}
-            where id = #{imageId}
+        UPDATE free_board_image_property
+        SET
+        board_id = #{boardId},
+        updated_at = now()
+        WHERE id IN
+        <foreach collection="imageIds" item="imageId" open="(" close=")" separator=",">
+            #{imageId}
         </foreach>
     </update>
 </mapper>

--- a/src/main/resources/mapper/file/NoticeBoardImagePropertyDaoMapper.xml
+++ b/src/main/resources/mapper/file/NoticeBoardImagePropertyDaoMapper.xml
@@ -1,10 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.pplip.domain.file.persistence.dao.NoticeBoardImagePropertyDao">
+<mapper namespace="com.pplip.domain.file.persistence.dao.mapper.NoticeBoardImagePropertyMapper">
+    <resultMap id="noticeBoardImagePropertyMap" type="com.pplip.domain.file.persistence.entity.NoticeBoardImageProperty" autoMapping="true"/>
     <insert id="insert">
-        insert into notice_board_image_property (board_id, origin_file_name, path, saved_file_name, size, created_at,
-                                                 updated_at)
-        values (#{boardId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{updatedAt});
+        insert into notice_board_image_property (board_id, origin_file_name, path, saved_file_name, size, content_type, created_at,
+                                                 updated_at, uploader_id)
+        values (#{boardId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{content_type},#{updatedAt}, #{uploaderId});
+    </insert>
+
+    <insert id="insertAll">
+        insert into notice_board_image_property (board_id, origin_file_name, path, saved_file_name, size, content_type,
+        created_at,
+        updated_at, uploader_id)
+        values
+        <foreach collection="list" index="index" item="image" separator=",">
+            (#{image.boardId}, #{image.originFileName}, #{image.path}, #{image.savedFileName}, #{image.size}, #{image.createdAt},
+            #{image.content_type},#{image.updatedAt}, #{image.uploaderId})
+        </foreach>
     </insert>
 
     <delete id="delete">
@@ -13,11 +25,29 @@
         where id = #{id};
     </delete>
 
+    <select id="findById" resultMap="noticeBoardImagePropertyMap">
+        select *
+        from notice_board_image_property
+        where id = #{id};
+    </select>
+
+    <select id="findAllByIds" resultMap="noticeBoardImagePropertyMap">
+        select *
+        from notice_board_image_property
+        where id in
+        <foreach collection="fileIds" item="id" open="(" close=")" separator=",">
+            #{id}
+        </foreach>
+    </select>
+
     <update id="bulkUpdateBoardId">
-        <foreach collection="imageIds" item="imageId" separator=";">
-            update notice_board_image_property
-            set board_id = #{boardId}
-            where id = #{imageId}
+        UPDATE notice_board_image_property
+        SET
+        board_id = #{boardId},
+        updated_at = now()
+        WHERE id IN
+        <foreach collection="imageIds" item="imageId" open="(" close=")" separator=",">
+            #{imageId}
         </foreach>
     </update>
 </mapper>

--- a/src/main/resources/mapper/file/ProfileImagePropertyDaoMapper.xml
+++ b/src/main/resources/mapper/file/ProfileImagePropertyDaoMapper.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.pplip.domain.file.persistence.dao.ProfileImagePropertyDao">
+<mapper namespace="com.pplip.domain.file.persistence.dao.mapper.ProfileImagePropertyMapper">
+
+    <resultMap id="profileImagePropertyMap" type="com.pplip.domain.file.persistence.entity.ProfileImageProperty" autoMapping="true"/>
     <insert id="insert">
-        insert into profile_image_property (profile_id, origin_file_name, path, saved_file_name, size, created_at,
-                                              updated_at)
-        values (#{profileId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{updatedAt});
+        insert into profile_image_property (profile_id, origin_file_name, path, saved_file_name, size, content_type, created_at,
+                                              updated_at, uploader_id)
+        values (#{profileId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{content_type} , #{createdAt}, #{updatedAt}, #{uploaderId});
     </insert>
 
     <delete id="delete">

--- a/src/main/resources/mapper/file/ReviewImagePropertyDaoMapper.xml
+++ b/src/main/resources/mapper/file/ReviewImagePropertyDaoMapper.xml
@@ -1,12 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.pplip.domain.file.persistence.dao.ReviewImagePropertyDao">
+<mapper namespace="com.pplip.domain.file.persistence.dao.mapper.ReviewImagePropertyMapper">
+    <resultMap id="reviewImagePropertyMap" type="ReviewImageProperty" autoMapping="true"/>
+
     <insert id="insert">
-        insert into review_image_property (review_id, origin_file_name, path, saved_file_name, size, created_at,
-                                              updated_at)
-        values (#{reviewId}, #{originFileName}, #{path}, #{savedFileName}, #{size}, #{createdAt}, #{updatedAt});
+        insert into review_image_property (review_id, origin_file_name, path, saved_file_name, content_type,size, created_at,
+                                              updated_at, uploader_id)
+        values (#{reviewId}, #{originFileName}, #{path}, #{savedFileName},#{content_type}, #{size}, #{createdAt}, #{updatedAt}, #{uploaderId});
     </insert>
 
+    <insert id="insertAll">
+        insert into review_image_property (review_id, origin_file_name, path, saved_file_name,content_type , size,
+        created_at,
+        updated_at, uploader_id)
+        values
+        <foreach collection="list" index="index" item="reviewImage" separator=",">
+            (#{reviewImage.reviewId}, #{reviewImage.originFileName}, #{reviewImage.path},
+            #{reviewImage.savedFileName},#{reviewImage.content_type}, #{reviewImage.size}, #{reviewImage.createdAt},
+            #{reviewImage.updatedAt}, #{reviewImage.uploaderId});
+        </foreach>
+    </insert>
+
+    <select id="findAllByIds" resultMap="reviewImagePropertyMap">
+        select *
+        from review_image_property
+        where id in
+        <foreach collection="fileIds" item="id" open="(" close=")" separator=",">
+            #{id}
+        </foreach>
+    </select>
     <delete id="delete">
         delete
         from review_image_property
@@ -14,10 +36,13 @@
     </delete>
 
     <update id="bulkUpdateReviewId">
-        <foreach collection="imageIds" item="imageId" separator=";">
-            update review_image_property
-            set review_id = #{review_id}
-            where id = #{imageId};
+        UPDATE free_board_image_property
+        SET
+        review_id = #{review_id},
+        updated_at = now()
+        WHERE id IN
+        <foreach collection="imageIds" item="imageId" open="(" close=")" separator=",">
+            #{imageId}
         </foreach>
     </update>
 </mapper>

--- a/src/main/resources/mapper/trip/attraction/TagDaoMapper.xml
+++ b/src/main/resources/mapper/trip/attraction/TagDaoMapper.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.pplip.domain.trip.attraction.persistence.dao.TagDao">
-    <select id="findAll" resultType="com.pplip.domain.trip.attraction.persistence.entity.Tag">
-        select * from tag
+
+    <resultMap id="tagMap" type="com.pplip.domain.trip.attraction.persistence.entity.Tag">
+        <id property="id" column="id"/>
+        <result property="name" column="name"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="tagMap">
+        select id, name, created_at from tag
         limit #{pageSize} offset #{offset};
     </select>
 
-    <select id="findAllByAttractionNo" resultType="com.pplip.domain.trip.attraction.persistence.entity.Tag">
-        select t.id as id,
-               t.name as name,
-               t.created_at as createdAt
+    <select id="findAllByAttractionNo" resultMap="tagMap">
+        select t.id,
+               t.name,
+               t.created_at
         from tag t
         join attraction_tag at on at.tag_id = t.id
         where at.attraction_id = #{no};

--- a/src/test/java/com/pplip/PplipApplicationTests.java
+++ b/src/test/java/com/pplip/PplipApplicationTests.java
@@ -1,6 +1,7 @@
 package com.pplip;
 
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest

--- a/src/test/java/com/pplip/domain/board/freeboard/persistence/dao/FreeBoardCommentDaoTest.java
+++ b/src/test/java/com/pplip/domain/board/freeboard/persistence/dao/FreeBoardCommentDaoTest.java
@@ -1,29 +1,108 @@
 package com.pplip.domain.board.freeboard.persistence.dao;
 
 import com.pplip.domain.board.freeboard.api.response.FreeBoardCommentResponse;
-import org.assertj.core.api.Assertions;
+import com.pplip.domain.board.freeboard.persistence.entity.FreeComment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.dao.DataIntegrityViolationException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("FreeBoardCommentDao 테스트")
 class FreeBoardCommentDaoTest {
 
     @Autowired
-    FreeBoardCommentDao dao;
+    private FreeBoardCommentDao freeBoardCommentDao;
+
+    private static final Long TEST_BOARD_ID = 1L;
+    private static final Long TEST_AUTHOR_ID = 1L;
+    private static final Long TEST_COMMENT_ID = 1L;
 
     @Test
-    @DisplayName("free board comment search")
-    void commentSearchAll() {
-        // when
-        List<FreeBoardCommentResponse.Retrieve> all = dao.findAll(1L);
-        // then
-        Assertions.assertThat(all.size()).isEqualTo(0);
+    @DisplayName("성공: 특정 게시글의 모든 댓글 조회")
+    void findAll_Success() {
+        // Given & When
+        List<FreeBoardCommentResponse.Retrieve> comments = assertDoesNotThrow(() -> freeBoardCommentDao.findAll(TEST_BOARD_ID));
+
+        // Then
+        assertNotNull(comments, "댓글 목록은 null이 아니어야 합니다.");
     }
 
+    @Test
+    @DisplayName("성공: 새 댓글 추가")
+    void insert_Success() {
+        // Given
+        FreeComment newComment = FreeComment.builder()
+                .boardId(TEST_BOARD_ID)
+                .authorId(TEST_AUTHOR_ID)
+                .content("새로운 자유게시판 댓글입니다.")
+                .isRemoved(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // When & Then
+        assertDoesNotThrow(() -> freeBoardCommentDao.insert(newComment));
+        assertThat(newComment.getId()).isNotNull();
+    }
+    
+    @Test
+    @DisplayName("실패: 존재하지 않는 게시글에 댓글 추가")
+    void insert_Fail_WithNonExistingBoardId() {
+        // Given
+        Long nonExistingBoardId = -1L;
+        FreeComment newComment = FreeComment.builder()
+                .boardId(nonExistingBoardId)
+                .authorId(TEST_AUTHOR_ID)
+                .content("이 댓글은 추가되어서는 안됩니다.")
+                .isRemoved(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // When & Then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            freeBoardCommentDao.insert(newComment);
+        });
+    }
+
+    @Test
+    @DisplayName("성공: 댓글 내용 수정")
+    void update_Success() {
+        // Given
+        FreeComment commentToUpdate = FreeComment.builder()
+                .id(TEST_COMMENT_ID)
+                .content("수정된 자유게시판 댓글입니다.")
+                .build();
+
+        // When
+        int affectedRows = assertDoesNotThrow(() -> freeBoardCommentDao.update(commentToUpdate));
+
+        // Then
+        assertThat(affectedRows).isLessThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("성공: 댓글 삭제 (논리적 삭제)")
+    void delete_Success() {
+        // Given
+        Long commentIdToDelete = TEST_COMMENT_ID;
+
+        // When
+        int affectedRows = assertDoesNotThrow(() -> freeBoardCommentDao.delete(commentIdToDelete));
+
+        // Then
+        assertThat(affectedRows).isLessThanOrEqualTo(1);
+    }
 }

--- a/src/test/java/com/pplip/domain/board/notice/persistence/dao/NoticeCommentDaoTest.java
+++ b/src/test/java/com/pplip/domain/board/notice/persistence/dao/NoticeCommentDaoTest.java
@@ -1,28 +1,117 @@
 package com.pplip.domain.board.notice.persistence.dao;
 
+import com.pplip.domain.board.notice.persistence.entity.NoticeComment;
 import com.pplip.domain.board.notice.api.response.NoticeCommentResponse;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.dao.DataIntegrityViolationException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("NoticeCommentDao 테스트")
 class NoticeCommentDaoTest {
 
     @Autowired
-    NoticeCommentDao dao;
+    private NoticeCommentDao noticeCommentDao;
+
+    private static final Long TEST_NOTICE_ID = 1L;
+    private static final Long TEST_AUTHOR_ID = 1L;
+    private static final Long TEST_COMMENT_ID = 1L;
 
     @Test
-    @DisplayName("find all test")
-    void findAll() {
-        // when
-        List<NoticeCommentResponse.Summary> all = dao.findAll(1L);
-        // then
-        Assertions.assertThat(all.size()).isEqualTo(0);
+    @DisplayName("성공: 특정 게시글의 모든 댓글 조회")
+    void findAll_Success() {
+        // Given & When
+        List<NoticeCommentResponse.Summary> comments = assertDoesNotThrow(() -> noticeCommentDao.findAll(TEST_NOTICE_ID));
+
+        // Then
+        assertNotNull(comments, "댓글 목록은 null이 아니어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("성공: 특정 게시글의 댓글 수 조회")
+    void noticeBoardCommentAllCount_Success() {
+        // Given & When
+        int count = assertDoesNotThrow(() -> noticeCommentDao.noticeBoardCommentAllCount(TEST_NOTICE_ID));
+
+        // Then
+        assertThat(count).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("성공: 새 댓글 추가")
+    void insert_Success() {
+        // Given
+        NoticeComment newComment = NoticeComment.builder()
+                .noticeBoardId(TEST_NOTICE_ID)
+                .authorId(TEST_AUTHOR_ID)
+                .content("새로운 댓글입니다.")
+                .isRemoved(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // When
+        // Then
+        assertDoesNotThrow(() -> noticeCommentDao.insert(newComment));
+        assertThat(newComment.getId()).isNotNull();
+    }
+    
+    @Test
+    @DisplayName("실패: 존재하지 않는 게시글에 댓글 추가")
+    void insert_Fail_WithNonExistingNoticeId() {
+        // Given
+        Long nonExistingNoticeId = -1L;
+        NoticeComment newComment = NoticeComment.builder()
+                .noticeBoardId(nonExistingNoticeId)
+                .authorId(TEST_AUTHOR_ID)
+                .content("이 댓글은 추가되어서는 안됩니다.")
+                .isRemoved(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // When & Then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            noticeCommentDao.insert(newComment);
+        });
+    }
+
+    @Test
+    @DisplayName("성공: 댓글 내용 수정")
+    void update_Success() {
+        // Given
+        NoticeComment commentToUpdate = NoticeComment.builder()
+                .id(TEST_COMMENT_ID)
+                .content("수정된 댓글입니다.")
+                .build();
+
+        // When
+        int affectedRows = assertDoesNotThrow(() -> noticeCommentDao.update(commentToUpdate));
+
+        // Then
+        assertThat(affectedRows).isLessThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("성공: 댓글 삭제 (논리적 삭제)")
+    void delete_Success() {
+        // Given
+        Long commentIdToDelete = TEST_COMMENT_ID;
+
+        // When
+        int affectedRows = assertDoesNotThrow(() -> noticeCommentDao.delete(commentIdToDelete));
+
+        // Then
+        assertThat(affectedRows).isLessThanOrEqualTo(1);
     }
 }

--- a/src/test/java/com/pplip/domain/file/api/controller/FileControllerTest.java
+++ b/src/test/java/com/pplip/domain/file/api/controller/FileControllerTest.java
@@ -1,0 +1,108 @@
+package com.pplip.domain.file.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pplip.domain.file.api.response.FileResponse;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.usecase.FileService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FileController.class)
+@DisplayName("FileController 테스트")
+@WithMockUser
+class FileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private FileService fileService;
+
+    @Test
+    @DisplayName("성공: 이미지 업로드")
+    void upload_Success() throws Exception {
+        // Given
+        MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
+        FileResponse fileResponse = FileResponse.builder().id(1L).path("/path/to/image.jpg").build();
+        given(fileService.saveFile(any(), any(ImageType.class), any())).willReturn(fileResponse);
+
+        // When
+        ResultActions actions = mockMvc.perform(
+                multipart("/file/image")
+                        .file(file)
+                        .param("imageType", "PROFILE")
+                        .with(csrf())
+        );
+
+        // Then
+        actions.andExpect(status().isOk()) // Expect 200 OK
+                .andExpect(jsonPath("$.code").value(201)) // Assert that the internal success code is 201 (CREATED)
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.path").value("/path/to/image.jpg"));
+    }
+
+    @Test
+    @DisplayName("성공: 여러 이미지 업로드")
+    void uploads_Success() throws Exception {
+        // Given
+        MockMultipartFile file1 = new MockMultipartFile("files", "test1.jpg", "image/jpeg", "test data 1".getBytes());
+        List<FileResponse> fileResponses = Collections.singletonList(FileResponse.builder().id(1L).path("/path/to/image1.jpg").build());
+        given(fileService.saveFiles(any(), any(ImageType.class), any())).willReturn(fileResponses);
+
+        // When
+        ResultActions actions = mockMvc.perform(
+                multipart("/file/images")
+                        .file(file1)
+                        .param("imageType", "REVIEW")
+                        .with(csrf())
+        );
+
+        // Then
+        actions.andExpect(status().isOk()) // Expect 200 OK
+                .andExpect(jsonPath("$.code").value(201)) // Assert that the internal success code is 201 (CREATED)
+                .andExpect(jsonPath("$.data[0].id").value(1L))
+                .andExpect(jsonPath("$.data[0].path").value("/path/to/image1.jpg"));
+    }
+
+    @Test
+    @DisplayName("성공: 이미지 파일 삭제")
+    void deleteFile_Success() throws Exception {
+        // Given
+        Long fileId = 1L;
+        FileResponse fileResponse = FileResponse.builder().id(fileId).path("/path/to/image.jpg").build();
+        given(fileService.remove(any(Long.class), any(ImageType.class), any())).willReturn(fileResponse);
+
+        // When
+        ResultActions actions = mockMvc.perform(
+                delete("/file/images/{id}", fileId)
+                        .param("imageType", "PROFILE")
+                        .with(csrf())
+        );
+
+        // Then
+        actions.andExpect(status().isOk()) // Expect 200 OK
+                .andExpect(jsonPath("$.code").value(203)) // Assert that the internal success code is 203 (REMOVED)
+                .andExpect(jsonPath("$.data.id").value(fileId));
+    }
+}

--- a/src/test/java/com/pplip/domain/file/usecase/AwsS3FileStorageTest.java
+++ b/src/test/java/com/pplip/domain/file/usecase/AwsS3FileStorageTest.java
@@ -1,0 +1,74 @@
+package com.pplip.domain.file.usecase;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.pplip.global.exception.BusinessLogicException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AwsS3FileStorage 테스트")
+class AwsS3FileStorageTest {
+
+    @Mock
+    private AmazonS3 s3Client;
+
+    @InjectMocks
+    private AwsS3FileStorage awsS3FileStorage;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(awsS3FileStorage, "bucketName", "test-bucket");
+    }
+
+    @Test
+    @DisplayName("성공: 파일 저장")
+    void store_Success() throws IOException {
+        // Given
+        MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
+        String path = "some/path/test.jpg";
+
+        // When
+        awsS3FileStorage.store(file, path);
+
+        // Then
+        verify(s3Client, times(1)).putObject(eq("test-bucket"), eq(path), any(), any());
+    }
+
+    @Test
+    @DisplayName("실패: 파일 저장 중 IOException 발생")
+    void store_Fail_WhenIOException() throws IOException {
+        // Given
+        MockMultipartFile file = mock(MockMultipartFile.class);
+        String path = "some/path/test.jpg";
+        when(file.getInputStream()).thenThrow(new IOException());
+
+        // When & Then
+        assertThrows(BusinessLogicException.class, () -> awsS3FileStorage.store(file, path));
+    }
+
+    @Test
+    @DisplayName("성공: 파일 삭제")
+    void delete_Success() {
+        // Given
+        String path = "some/path/test.jpg";
+
+        // When
+        awsS3FileStorage.delete(path);
+
+        // Then
+        verify(s3Client, times(1)).deleteObject("test-bucket", path);
+    }
+}

--- a/src/test/java/com/pplip/domain/file/usecase/FileServiceImplTest.java
+++ b/src/test/java/com/pplip/domain/file/usecase/FileServiceImplTest.java
@@ -1,0 +1,196 @@
+package com.pplip.domain.file.usecase;
+
+import com.pplip.domain.auth.persistence.entity.Account;
+import com.pplip.domain.auth.utils.SecurityUtils;
+import com.pplip.domain.file.api.response.FileResponse;
+import com.pplip.domain.file.persistence.dao.BatchSupportFilePropertyDao;
+import com.pplip.domain.file.persistence.dao.FilePropertyDao;
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.ProfileImageProperty;
+import com.pplip.domain.file.utils.FilePropertyProvider;
+import com.pplip.domain.file.utils.FileStorage;
+import com.pplip.domain.user.persistence.entity.User;
+import com.pplip.global.exception.BusinessLogicException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FileServiceImpl 테스트")
+class FileServiceImplTest {
+
+    @InjectMocks
+    private FileServiceImpl fileService;
+
+    @Mock
+    private FilePropertyProvider provider;
+
+    @Mock
+    private FileStorage fileStorage;
+
+    @Mock
+    private SecurityUtils securityUtils;
+    
+    @Mock
+    private FilePropertyDao<FileProperty> filePropertyDao;
+
+    @Mock
+    private BatchSupportFilePropertyDao<FileProperty> batchSupportFilePropertyDao;
+
+    private User testUser;
+    private Account testUserDetails;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder().id(1L).name("testuser").build();
+        testUserDetails = new Account();
+        testUserDetails.setUserId(testUser.getId());
+        testUserDetails.setEmail("test@test.com");
+        
+        // Since the service uses lists of DAOs, we need to re-inject them before each test.
+        fileService = new FileServiceImpl(provider, fileStorage, securityUtils, List.of(filePropertyDao), List.of(batchSupportFilePropertyDao));
+    }
+
+    @Test
+    @DisplayName("성공: 단일 파일 저장")
+    void saveFile_Success() {
+        // Given
+        MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
+        ImageType imageType = ImageType.PROFILE;
+        FileProperty fileProperty = ProfileImageProperty.builder().id(1L).path("/path/to/test.jpg").originFileName("test.jpg").contentType("image/jpeg").size(100L).uploaderId(testUser.getId()).build();
+
+        when(securityUtils.getLoginUser(any())).thenReturn(testUser);
+        when(provider.create(any(), any(), any(), any(), any())).thenReturn(fileProperty);
+        when(filePropertyDao.supports(imageType)).thenReturn(true);
+        when(filePropertyDao.insert(any())).thenReturn(1);
+        doNothing().when(fileStorage).store(any(), any());
+
+        // When
+        FileResponse response = fileService.saveFile(file, imageType, testUserDetails);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(fileProperty.getId());
+        verify(fileStorage).store(file, fileProperty.getPath());
+        verify(filePropertyDao).insert(fileProperty);
+    }
+    
+    @Test
+    @DisplayName("실패: 지원하지 않는 이미지 타입으로 파일 저장")
+    void saveFile_Fail_UnsupportedType() {
+        // Given
+        MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
+        ImageType imageType = ImageType.PROFILE;
+
+        when(securityUtils.getLoginUser(any())).thenReturn(testUser);
+        when(provider.create(any(), any(), any(), any(), any())).thenReturn(ProfileImageProperty.builder().build());
+        when(filePropertyDao.supports(imageType)).thenReturn(false);
+
+        // When & Then
+        assertThrows(BusinessLogicException.class, () -> {
+            fileService.saveFile(file, imageType, testUserDetails);
+        });
+    }
+
+    @Test
+    @DisplayName("성공: 파일 삭제")
+    void remove_Success() {
+        // Given
+        Long fileId = 1L;
+        ImageType imageType = ImageType.PROFILE;
+        FileProperty fileProperty = ProfileImageProperty.builder().id(fileId).uploaderId(testUser.getId()).path("/path/to/file").build();
+
+        when(securityUtils.getLoginUser(any())).thenReturn(testUser);
+        when(filePropertyDao.supports(imageType)).thenReturn(true);
+        when(filePropertyDao.findById(fileId)).thenReturn(Optional.of(fileProperty));
+        when(filePropertyDao.delete(fileId)).thenReturn(1);
+        doNothing().when(fileStorage).delete(any());
+
+        // When
+        FileResponse response = fileService.remove(fileId, imageType, testUserDetails);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(fileId);
+        verify(fileStorage).delete(fileProperty.getPath());
+    }
+
+    @Test
+    @DisplayName("실패: 다른 사용자의 파일 삭제 시도")
+    void remove_Fail_InvalidUser() {
+        // Given
+        Long fileId = 1L;
+        ImageType imageType = ImageType.PROFILE;
+        FileProperty fileProperty = ProfileImageProperty.builder().id(fileId).uploaderId(2L).build(); // Different user ID
+
+        when(securityUtils.getLoginUser(any())).thenReturn(testUser);
+        when(filePropertyDao.supports(imageType)).thenReturn(true);
+        when(filePropertyDao.findById(fileId)).thenReturn(Optional.of(fileProperty));
+
+        // When & Then
+        assertThrows(BusinessLogicException.class, () -> {
+            fileService.remove(fileId, imageType, testUserDetails);
+        });
+    }
+    
+    @Test
+    @DisplayName("성공: 다중 파일 저장")
+    void saveFiles_Success() {
+        // Given
+        List<MultipartFile> files = List.of(
+            new MockMultipartFile("file1", "test1.jpg", "image/jpeg", "test data 1".getBytes()),
+            new MockMultipartFile("file2", "test2.jpg", "image/jpeg", "test data 2".getBytes())
+        );
+        ImageType imageType = ImageType.REVIEW;
+        FileProperty fp1 = ProfileImageProperty.builder().id(1L).build();
+        FileProperty fp2 = ProfileImageProperty.builder().id(2L).build();
+
+        when(securityUtils.getLoginUser(any())).thenReturn(testUser);
+        when(provider.create(eq("test1.jpg"), any(), any(), any(), any())).thenReturn(fp1);
+        when(provider.create(eq("test2.jpg"), any(), any(), any(), any())).thenReturn(fp2);
+        when(batchSupportFilePropertyDao.supports(imageType)).thenReturn(true);
+        
+        // When
+        List<FileResponse> responses = fileService.saveFiles(files, imageType, testUserDetails);
+
+        // Then
+        assertThat(responses).hasSize(2);
+        verify(fileStorage, times(2)).store(any(), any());
+        verify(batchSupportFilePropertyDao).insertAll(List.of(fp1, fp2));
+    }
+    
+    @Test
+    @DisplayName("성공: 파일 정보 일괄 업데이트")
+    void bulkUpdateFiles_Success() {
+        // Given
+        List<Long> fileIds = List.of(1L, 2L);
+        Long refId = 100L;
+        ImageType imageType = ImageType.REVIEW;
+        
+        when(batchSupportFilePropertyDao.supports(imageType)).thenReturn(true);
+        when(batchSupportFilePropertyDao.bulkUpdate(fileIds, refId)).thenReturn(2);
+
+        // When
+        int updatedCount = fileService.bulkUpdateFiles(fileIds, imageType, refId);
+
+        // Then
+        assertThat(updatedCount).isEqualTo(2);
+        verify(batchSupportFilePropertyDao).bulkUpdate(fileIds, refId);
+    }
+}

--- a/src/test/java/com/pplip/domain/file/utils/FilePathGeneratorTest.java
+++ b/src/test/java/com/pplip/domain/file/utils/FilePathGeneratorTest.java
@@ -1,0 +1,52 @@
+package com.pplip.domain.file.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("FilePathGenerator 테스트")
+class FilePathGeneratorTest {
+
+    private FilePathGenerator filePathGenerator;
+
+    @BeforeEach
+    void setUp() {
+        filePathGenerator = new FilePathGenerator();
+    }
+
+    @Test
+    @DisplayName("성공: 파일 경로 생성")
+    void generatePath_Success() {
+        // Given
+        String saveName = "test-save-name.jpg";
+        LocalDateTime now = LocalDateTime.now();
+        String expectedPathPrefix = now.getYear() + "/" + now.getMonth() + "/" + now.getDayOfMonth();
+
+        // When
+        String generatedPath = filePathGenerator.generatePath(saveName);
+
+        // Then
+        assertTrue(generatedPath.startsWith(expectedPathPrefix));
+        assertTrue(generatedPath.endsWith(saveName));
+    }
+
+    @Test
+    @DisplayName("성공: 저장 파일 이름 생성")
+    void generateSaveFileName_Success() {
+        // Given
+        String originFileName = "original.png";
+
+        // When
+        String saveFileName = filePathGenerator.generateSaveFileName(originFileName);
+
+        // Then
+        assertNotNull(saveFileName);
+        assertNotEquals(originFileName, saveFileName);
+        assertTrue(saveFileName.endsWith(".png"));
+        assertFalse(saveFileName.contains("-"));
+    }
+}

--- a/src/test/java/com/pplip/domain/file/utils/FilePropertyProviderTest.java
+++ b/src/test/java/com/pplip/domain/file/utils/FilePropertyProviderTest.java
@@ -1,0 +1,83 @@
+package com.pplip.domain.file.utils;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.utils.factory.FilePropertyFactory;
+import com.pplip.domain.user.persistence.entity.User;
+import com.pplip.global.exception.BusinessLogicException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FilePropertyProvider 테스트")
+class FilePropertyProviderTest {
+
+    @Mock
+    private FilePathGenerator filePathGenerator;
+
+    @Mock
+    private FilePropertyFactory filePropertyFactory;
+
+    @InjectMocks
+    private FilePropertyProvider filePropertyProvider;
+
+    @Test
+    @DisplayName("성공: 파일 속성 생성")
+    void create_Success() {
+        // Given
+        String fileName = "test.jpg";
+        String contentType = "image/jpeg";
+        Long size = 1024L;
+        User uploader = new User();
+        ImageType imageType = ImageType.FREE_BOARD;
+
+        // filePropertyProvider의 fileProperties 필드를 mock FilePropertyFactory를 포함하는 리스트로 설정
+        filePropertyProvider = new FilePropertyProvider(List.of(filePropertyFactory), filePathGenerator);
+
+        when(filePathGenerator.generatePath(anyString())).thenReturn("some/path/test.jpg");
+        when(filePathGenerator.generateSaveFileName(anyString())).thenReturn("saved-name.jpg");
+        when(filePropertyFactory.support(imageType)).thenReturn(true);
+        when(filePropertyFactory.create(anyString(), anyString(), anyString(), anyString(), anyLong(), any(User.class), any(ImageType.class)))
+                .thenReturn(mock(FileProperty.class));
+
+        // When
+        FileProperty result = filePropertyProvider.create(fileName, contentType, size, uploader, imageType);
+
+        // Then
+        assertNotNull(result);
+        verify(filePropertyFactory, times(1)).create(anyString(), anyString(), anyString(), anyString(), anyLong(), any(User.class), any(ImageType.class));
+    }
+
+    @Test
+    @DisplayName("실패: 지원하는 팩토리가 없음")
+    void create_Fail_WhenNoSupportingFactory() {
+        // Given
+        String fileName = "test.jpg";
+        String contentType = "image/jpeg";
+        Long size = 1024L;
+        User uploader = new User();
+        ImageType imageType = ImageType.FREE_BOARD;
+
+        filePropertyProvider = new FilePropertyProvider(Collections.emptyList(), filePathGenerator);
+        
+        when(filePathGenerator.generatePath(anyString())).thenReturn("some/path/test.jpg");
+        when(filePathGenerator.generateSaveFileName(anyString())).thenReturn("saved-name.jpg");
+
+        // When & Then
+        assertThrows(BusinessLogicException.class,
+                () -> filePropertyProvider.create(fileName, contentType, size, uploader, imageType));
+    }
+}

--- a/src/test/java/com/pplip/domain/file/utils/factory/FreeBoardImagePropertyFactoryTest.java
+++ b/src/test/java/com/pplip/domain/file/utils/factory/FreeBoardImagePropertyFactoryTest.java
@@ -1,0 +1,69 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.FreeBoardImageProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.user.persistence.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("FreeBoardImagePropertyFactory 테스트")
+class FreeBoardImagePropertyFactoryTest {
+
+    private FreeBoardImagePropertyFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new FreeBoardImagePropertyFactory();
+    }
+
+    @Test
+    @DisplayName("성공: FreeBoardImageProperty 생성")
+    void create_Success() {
+        // Given
+        String originFileName = "origin.jpg";
+        String savedFileName = "saved.jpg";
+        String path = "path/to/file";
+        String contentType = "image/jpeg";
+        Long size = 1024L;
+        User uploader = User.builder().id(1L).build();
+
+        // When
+        FileProperty property = factory.create(originFileName, savedFileName, path, contentType, size, uploader, ImageType.FREE_BOARD);
+
+        // Then
+        assertNotNull(property);
+        assertTrue(property instanceof FreeBoardImageProperty);
+        assertEquals(originFileName, property.getOriginFileName());
+        assertEquals(savedFileName, property.getSavedFileName());
+        assertEquals(path, property.getPath());
+        assertEquals(contentType, property.getContentType());
+        assertEquals(size, property.getSize());
+        assertEquals(uploader.getId(), property.getUploaderId());
+    }
+
+    @Test
+    @DisplayName("성공: FREE_BOARD 타입 지원")
+    void support_Success_ForFreeBoard() {
+        // When
+        boolean supports = factory.support(ImageType.FREE_BOARD);
+
+        // Then
+        assertTrue(supports);
+    }
+
+    @Test
+    @DisplayName("실패: 다른 타입 미지원")
+    void support_Fail_ForOtherTypes() {
+        // When
+        boolean supportsProfile = factory.support(ImageType.PROFILE);
+        boolean supportsNotice = factory.support(ImageType.NOTICE);
+
+        // Then
+        assertFalse(supportsProfile);
+        assertFalse(supportsNotice);
+    }
+}

--- a/src/test/java/com/pplip/domain/file/utils/factory/NoticeBoardImagePropertyFactoryTest.java
+++ b/src/test/java/com/pplip/domain/file/utils/factory/NoticeBoardImagePropertyFactoryTest.java
@@ -1,0 +1,69 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.NoticeBoardImageProperty;
+import com.pplip.domain.user.persistence.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("NoticeBoardImagePropertyFactory 테스트")
+class NoticeBoardImagePropertyFactoryTest {
+
+    private NoticeBoardImagePropertyFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new NoticeBoardImagePropertyFactory();
+    }
+
+    @Test
+    @DisplayName("성공: NoticeBoardImageProperty 생성")
+    void create_Success() {
+        // Given
+        String originFileName = "origin.jpg";
+        String savedFileName = "saved.jpg";
+        String path = "path/to/file";
+        String contentType = "image/jpeg";
+        Long size = 1024L;
+        User uploader = User.builder().id(1L).build();
+
+        // When
+        FileProperty property = factory.create(originFileName, savedFileName, path, contentType, size, uploader, ImageType.NOTICE);
+
+        // Then
+        assertNotNull(property);
+        assertTrue(property instanceof NoticeBoardImageProperty);
+        assertEquals(originFileName, property.getOriginFileName());
+        assertEquals(savedFileName, property.getSavedFileName());
+        assertEquals(path, property.getPath());
+        assertEquals(contentType, property.getContentType());
+        assertEquals(size, property.getSize());
+        assertEquals(uploader.getId(), property.getUploaderId());
+    }
+
+    @Test
+    @DisplayName("성공: NOTICE 타입 지원")
+    void support_Success_ForNotice() {
+        // When
+        boolean supports = factory.support(ImageType.NOTICE);
+
+        // Then
+        assertTrue(supports);
+    }
+
+    @Test
+    @DisplayName("실패: 다른 타입 미지원")
+    void support_Fail_ForOtherTypes() {
+        // When
+        boolean supportsProfile = factory.support(ImageType.PROFILE);
+        boolean supportsFreeBoard = factory.support(ImageType.FREE_BOARD);
+
+        // Then
+        assertFalse(supportsProfile);
+        assertFalse(supportsFreeBoard);
+    }
+}

--- a/src/test/java/com/pplip/domain/file/utils/factory/ProfileImagePropertyFactoryTest.java
+++ b/src/test/java/com/pplip/domain/file/utils/factory/ProfileImagePropertyFactoryTest.java
@@ -1,0 +1,69 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.ProfileImageProperty;
+import com.pplip.domain.user.persistence.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ProfileImagePropertyFactory 테스트")
+class ProfileImagePropertyFactoryTest {
+
+    private ProfileImagePropertyFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new ProfileImagePropertyFactory();
+    }
+
+    @Test
+    @DisplayName("성공: ProfileImageProperty 생성")
+    void create_Success() {
+        // Given
+        String originFileName = "origin.jpg";
+        String savedFileName = "saved.jpg";
+        String path = "path/to/file";
+        String contentType = "image/jpeg";
+        Long size = 1024L;
+        User uploader = User.builder().id(1L).build();
+
+        // When
+        FileProperty property = factory.create(originFileName, savedFileName, path, contentType, size, uploader, ImageType.PROFILE);
+
+        // Then
+        assertNotNull(property);
+        assertTrue(property instanceof ProfileImageProperty);
+        assertEquals(originFileName, property.getOriginFileName());
+        assertEquals(savedFileName, property.getSavedFileName());
+        assertEquals(path, property.getPath());
+        assertEquals(contentType, property.getContentType());
+        assertEquals(size, property.getSize());
+        assertEquals(uploader.getId(), property.getUploaderId());
+    }
+
+    @Test
+    @DisplayName("성공: PROFILE 타입 지원")
+    void support_Success_ForProfile() {
+        // When
+        boolean supports = factory.support(ImageType.PROFILE);
+
+        // Then
+        assertTrue(supports);
+    }
+
+    @Test
+    @DisplayName("실패: 다른 타입 미지원")
+    void support_Fail_ForOtherTypes() {
+        // When
+        boolean supportsNotice = factory.support(ImageType.NOTICE);
+        boolean supportsFreeBoard = factory.support(ImageType.FREE_BOARD);
+
+        // Then
+        assertFalse(supportsNotice);
+        assertFalse(supportsFreeBoard);
+    }
+}

--- a/src/test/java/com/pplip/domain/file/utils/factory/ReviewImagePropertyFactoryTest.java
+++ b/src/test/java/com/pplip/domain/file/utils/factory/ReviewImagePropertyFactoryTest.java
@@ -1,0 +1,69 @@
+package com.pplip.domain.file.utils.factory;
+
+import com.pplip.domain.file.persistence.entity.FileProperty;
+import com.pplip.domain.file.persistence.entity.ImageType;
+import com.pplip.domain.file.persistence.entity.ReviewImageProperty;
+import com.pplip.domain.user.persistence.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ReviewImagePropertyFactory 테스트")
+class ReviewImagePropertyFactoryTest {
+
+    private ReviewImagePropertyFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new ReviewImagePropertyFactory();
+    }
+
+    @Test
+    @DisplayName("성공: ReviewImageProperty 생성")
+    void create_Success() {
+        // Given
+        String originFileName = "origin.jpg";
+        String savedFileName = "saved.jpg";
+        String path = "path/to/file";
+        String contentType = "image/jpeg";
+        Long size = 1024L;
+        User uploader = User.builder().id(1L).build();
+
+        // When
+        FileProperty property = factory.create(originFileName, savedFileName, path, contentType, size, uploader, ImageType.REVIEW);
+
+        // Then
+        assertNotNull(property);
+        assertTrue(property instanceof ReviewImageProperty);
+        assertEquals(originFileName, property.getOriginFileName());
+        assertEquals(savedFileName, property.getSavedFileName());
+        assertEquals(path, property.getPath());
+        assertEquals(contentType, property.getContentType());
+        assertEquals(size, property.getSize());
+        assertEquals(uploader.getId(), property.getUploaderId());
+    }
+
+    @Test
+    @DisplayName("성공: REVIEW 타입 지원")
+    void support_Success_ForReview() {
+        // When
+        boolean supports = factory.support(ImageType.REVIEW);
+
+        // Then
+        assertTrue(supports);
+    }
+
+    @Test
+    @DisplayName("실패: 다른 타입 미지원")
+    void support_Fail_ForOtherTypes() {
+        // When
+        boolean supportsProfile = factory.support(ImageType.PROFILE);
+        boolean supportsFreeBoard = factory.support(ImageType.FREE_BOARD);
+
+        // Then
+        assertFalse(supportsProfile);
+        assertFalse(supportsFreeBoard);
+    }
+}

--- a/src/test/java/com/pplip/domain/trip/attraction/persistence/dao/SidoGugunDaoTest.java
+++ b/src/test/java/com/pplip/domain/trip/attraction/persistence/dao/SidoGugunDaoTest.java
@@ -1,56 +1,80 @@
 package com.pplip.domain.trip.attraction.persistence.dao;
 
 import com.pplip.domain.trip.attraction.api.response.AttractionResponse;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("SidoGugunDao 테스트")
 class SidoGugunDaoTest {
 
     @Autowired
-    SidoGugunDao dao;
+    private SidoGugunDao sidoGugunDao;
 
     @Test
-    @DisplayName("find all sidogungu")
-    void findAllSidogungu() {
-        // given
-        List<AttractionResponse.Gugun> allGugun = dao.findAllGugun();
-        // when
-        Assertions.assertThat(allGugun.size()).isEqualTo(0);
-        // then
+    @DisplayName("성공: 모든 지역 정보 조회")
+    void findAllRegion_Success() {
+        // Given & When
+        List<AttractionResponse.Region> regions = assertDoesNotThrow(() -> sidoGugunDao.findAllRegion());
+
+        // Then
+        assertNotNull(regions);
     }
 
     @Test
-    @DisplayName("findAllRegion")
-    void findAllRegion() {
-        // when
-        List<AttractionResponse.Region> allRegion = dao.findAllRegion();
-        // then
-        Assertions.assertThat(allRegion.size()).isEqualTo(0);
+    @DisplayName("성공: 모든 시도 정보 조회")
+    void findAllSido_Success() {
+        // Given & When
+        List<AttractionResponse.Sido> sidos = assertDoesNotThrow(() -> sidoGugunDao.findAllSido());
+
+        // Then
+        assertNotNull(sidos);
     }
 
     @Test
-    @DisplayName("findAllSido")
-    void findAllSido() {
-        // when
-        List<AttractionResponse.Sido> allSido = dao.findAllSido();
-        // then
-        Assertions.assertThat(allSido.size()).isEqualTo(0);
+    @DisplayName("성공: 모든 구군 정보 조회")
+    void findAllGugun_Success() {
+        // Given & When
+        List<AttractionResponse.Gugun> guguns = assertDoesNotThrow(() -> sidoGugunDao.findAllGugun());
+
+        // Then
+        assertNotNull(guguns);
     }
 
     @Test
-    @DisplayName("findOne")
-    void findOne() {
-        // when
-        List<AttractionResponse.Gugun> allGugunInSido = dao.findAllGugunInSido(1L);
-        // then
-        Assertions.assertThat(allGugunInSido.size()).isEqualTo(0);
+    @DisplayName("성공: 특정 시도의 구군 정보 조회")
+    void findAllGugunInSido_Success() {
+        // Given
+        Long sidoCode = 1L; // Assuming 1 is a valid sido_code (e.g., 서울)
+
+        // When
+        List<AttractionResponse.Gugun> guguns = assertDoesNotThrow(() -> sidoGugunDao.findAllGugunInSido(sidoCode));
+
+        // Then
+        assertNotNull(guguns);
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 존재하지 않는 시도 코드로 구군 정보 조회")
+    void findAllGugunInSido_Fail_WhenSidoCodeNotFound() {
+        // Given
+        Long nonExistentSidoCode = 9999L;
+
+        // When
+        List<AttractionResponse.Gugun> guguns = assertDoesNotThrow(() -> sidoGugunDao.findAllGugunInSido(nonExistentSidoCode));
+
+        // Then
+        assertNotNull(guguns);
+        assertThat(guguns).isEmpty();
     }
 }

--- a/src/test/java/com/pplip/domain/trip/attraction/persistence/dao/TagDaoTest.java
+++ b/src/test/java/com/pplip/domain/trip/attraction/persistence/dao/TagDaoTest.java
@@ -2,37 +2,50 @@ package com.pplip.domain.trip.attraction.persistence.dao;
 
 import com.pplip.domain.trip.attraction.persistence.entity.Tag;
 import com.pplip.global.page.PageRequest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TagDaoTest {
 
     @Autowired
     TagDao dao;
 
     @Test
-    @DisplayName("findAll")
-    void findAll() {
+    @DisplayName("성공: 모든 태그 조회 (페이지네이션)")
+    void findAll_Success() {
         // when
-        List<Tag> all = dao.findAll(new PageRequest(1, 20));
+        List<Tag> all = assertDoesNotThrow(() -> dao.findAll(new PageRequest(1, 20)));
         // then
-        Assertions.assertThat(all.size()).isEqualTo(0);
+        assertNotNull(all);
     }
 
     @Test
-    @DisplayName("find by no")
-    void findByNo() {
+    @DisplayName("성공: 특정 명소의 태그 조회")
+    void findByNo_Success() {
         // when
-        List<Tag> allByAttractionNo = dao.findAllByAttractionNo(1L);
+        List<Tag> allByAttractionNo = assertDoesNotThrow(() -> dao.findAllByAttractionNo(1L));
         // then
-        Assertions.assertThat(allByAttractionNo.size()).isEqualTo(0);
+        assertNotNull(allByAttractionNo);
+    }
+
+    @Test
+    @DisplayName("엣지 케이스: 존재하지 않는 명소의 태그 조회")
+    void findByNo_Fail_WhenNotFound() {
+        // when
+        List<Tag> allByAttractionNo = assertDoesNotThrow(() -> dao.findAllByAttractionNo(9999L));
+        // then
+        assertNotNull(allByAttractionNo);
+        assertThat(allByAttractionNo).isEmpty();
     }
 }

--- a/src/test/java/com/pplip/domain/trip/review/persistence/dao/ReviewDaoTest.java
+++ b/src/test/java/com/pplip/domain/trip/review/persistence/dao/ReviewDaoTest.java
@@ -21,6 +21,7 @@ class ReviewDaoTest {
     @DisplayName("find all by no")
     void findAllByNo() {
         // when
+
         List<ReviewResponse.Detail> allByAttractionNo = dao.findAllByAttractionNo(1L);
         // then
         Assertions.assertThat(allByAttractionNo.size()).isEqualTo(0);

--- a/src/test/java/com/pplip/domain/user/persistence/dao/UserDaoTest.java
+++ b/src/test/java/com/pplip/domain/user/persistence/dao/UserDaoTest.java
@@ -1,39 +1,94 @@
 package com.pplip.domain.user.persistence.dao;
 
 import com.pplip.domain.user.persistence.entity.User;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
-@SpringBootTest
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+@MybatisTest
 @Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserDaoTest {
 
     @Autowired
     UserDao dao;
 
     @Test
-    @DisplayName("find one")
-    void findOne() {
+    @DisplayName("성공: DB에 저장된 유저를 ID로 찾을 수 있다")
+    void findById_ShouldFindUser_WhenUserExists() {
+        // given
+        User user = User.builder()
+                .name("testUser")
+                .birth(LocalDate.now())
+                .build();
+        dao.insert(user);
+
         // when
-        Optional<User> byId = dao.findById(1L);
+        Optional<User> foundUserOptional = dao.findById(user.getId());
+
         // then
-        System.out.println(byId.get().getId());
+        assertThat(foundUserOptional).isPresent();
+        foundUserOptional.ifPresent(foundUser -> {
+            assertThat(foundUser.getId()).isEqualTo(user.getId());
+            assertThat(foundUser.getName()).isEqualTo(user.getName());
+            assertThat(foundUser.getBirth()).isEqualTo(user.getBirth());
+        });
     }
 
     @Test
-    @DisplayName("insert test")
-    void insert() {
+    @DisplayName("성공: 존재하지 않는 ID로 조회 시 빈 Optional을 반환한다")
+    void findById_ShouldReturnEmpty_WhenUserDoesNotExist() {
         // given
-        User user = User.builder().name("user1").birth(LocalDate.of(2000, 2, 11)).build();
+        long nonExistentId = 999L;
+
+        // when
+        Optional<User> foundUserOptional = dao.findById(nonExistentId);
+
+        // then
+        assertThat(foundUserOptional).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("성공: 새로운 유저를 DB에 저장할 수 있다")
+    void insert_ShouldSaveUser() {
+        // given
+        User user = User.builder()
+                .name("newUser")
+                .birth(LocalDate.now())
+                .build();
+
         // when
         dao.insert(user);
+
         // then
+        Optional<User> foundUserOptional = dao.findById(user.getId());
+        assertThat(foundUserOptional).isPresent();
+        assertThat(foundUserOptional.get().getName()).isEqualTo("newUser");
+    }
+
+    @Test
+    @DisplayName("실패: 필수 필드(name)가 null이면 DataIntegrityViolationException 예외가 발생한다")
+    void insert_ShouldThrowException_WhenNameIsNull() {
+        // given
+        User user = User.builder()
+                .birth(LocalDate.now())
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> dao.insert(user))
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 }

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE sidos (
+    sido_code INT PRIMARY KEY,
+    sido_name VARCHAR(255)
+);
+
+CREATE TABLE guguns (
+    gugun_code INT PRIMARY KEY,
+    gugun_name VARCHAR(255),
+    sido_code INT
+);


### PR DESCRIPTION
1. AWS S3를 연동하여 이미지 등 파일을 업로드하고 관리하는 기능을 구현했습니다.
 2. 프로필, 게시판(자유, 공지), 리뷰 등 각 도메인에 이미지 첨부 기능을 적용했습니다.
 3. MyBatis의 Mapper 인터페이스를 사용하도록 DAO와 Mapper.xml을 리팩토링했습니다.
 4  변경된 로직에 맞춰 테스트 코드를 Junit5, MybatisTest 기반으로 재작성 및 보강했습니다.
 5  파일 API 엔드포인트와 Swagger UI 접근을 위한 Spring Security 설정을 업데이트했습니다.
 6  AWS S3 연동 및 Swagger 설정 정보를 application.yml에 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 파일 업로드 기능 추가: 단일 및 다중 이미지 업로드 지원
  * 파일 삭제 기능 구현
  * AWS S3 클라우드 스토리지 연동으로 안정적인 파일 관리 제공
  * 다양한 이미지 타입(프로필, 자유게시판, 공지사항, 리뷰) 지원

* **테스트**
  * 파일 관리 및 업로드 기능 테스트 추가
  * DAO 및 매퍼 테스트 확대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->